### PR TITLE
Add more unit tests for domain and services

### DIFF
--- a/notas.Tests/TestEmpresa.cs
+++ b/notas.Tests/TestEmpresa.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Xunit;
+using System.Threading;
 using notas.Server.Backend.Domain.Entities;
 using notas.Server.Backend.Domain.ValueObjects;
 using notas.Server.Backend.Domain.Enums;
@@ -97,6 +98,28 @@ namespace notas.Tests
             var endereco = CriarEnderecoDummy();
             var empresa = new Empresa("Teste", "Teste Fantasia", "12345678910111", endereco);
             Assert.Equal("Teste (12345678910111)", empresa.ToString());
+        }
+
+        [Fact]
+        public void AlternarAtivacao_DeveAtualizarDataUltimaAtualizacao()
+        {
+            var endereco = CriarEnderecoDummy();
+            var empresa = new Empresa("Teste", "Teste Fantasia", "12345678910111", endereco);
+            var antes = empresa.DataUltimaAtualizacao;
+            Thread.Sleep(1);
+            empresa.AlternarAtivacao();
+            Assert.True(empresa.DataUltimaAtualizacao > antes);
+        }
+
+        [Fact]
+        public void AtualizarDados_DeveAtualizarDataUltimaAtualizacao()
+        {
+            var endereco = CriarEnderecoDummy();
+            var empresa = new Empresa("Teste", "Teste Fantasia", "12345678910111", endereco);
+            var antes = empresa.DataUltimaAtualizacao;
+            Thread.Sleep(1);
+            empresa.AtualizarDados("Nova Razao Social", "Novo Nome Fantasia", CriarEnderecoDummy());
+            Assert.True(empresa.DataUltimaAtualizacao > antes);
         }
 
     }

--- a/notas.Tests/TestEmpresaService.cs
+++ b/notas.Tests/TestEmpresaService.cs
@@ -117,5 +117,18 @@ namespace notas.Tests
             Assert.Equal(2, resultado.Count());
             repoMock.Verify(r => r.ListarTodasAsync(), Times.Once);
         }
+
+        [Fact]
+        public async Task ListarEmpresasAsync_DeveRetornarListaVazia_QuandoNaoExistemEmpresas()
+        {
+            var repoMock = new Mock<IEmpresaRepository>();
+            repoMock.Setup(r => r.ListarTodasAsync()).ReturnsAsync(new List<Empresa>());
+
+            var service = new EmpresaService(repoMock.Object);
+            var resultado = await service.ListarEmpresasAsync();
+
+            Assert.Empty(resultado);
+            repoMock.Verify(r => r.ListarTodasAsync(), Times.Once);
+        }
     }
 }

--- a/notas.Tests/TestEndereco.cs
+++ b/notas.Tests/TestEndereco.cs
@@ -50,5 +50,12 @@ namespace notas.Tests
             Assert.Equal(esperadoValido, valido);
         }
 
+        [Fact]
+        public void ToString_DeveRetornarFormatado()
+        {
+            var endereco = new Endereco("Rua A", "", "123", "Centro", "Cidade", UF.SP, "30110-020");
+            Assert.Equal("Rua A, 123 - Centro, Cidade - SP, 30110020", endereco.ToString());
+        }
+
     }
 }

--- a/notas.Tests/TestNotaFiscal.cs
+++ b/notas.Tests/TestNotaFiscal.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Globalization;
+using notas.Server.Backend.Domain.Entities;
+using notas.Server.Backend.Domain.Enums;
+using notas.Server.Backend.Domain.ValueObjects;
+using Xunit;
+
+namespace notas.Tests
+{
+    public class TestNotaFiscal
+    {
+        private Endereco DummyEndereco() => new Endereco("Rua A", "", "123", "Centro", "Cidade", UF.MG, "30110-020");
+        private Empresa DummyEmpresa(string razao, string cnpj) => new Empresa(razao, razao, cnpj, DummyEndereco());
+
+        [Fact]
+        public void CriarNotaFiscal_ComOrigemNula_DeveLancarExcecao()
+        {
+            var destino = DummyEmpresa("Destino", "10987654321011");
+            Assert.Throws<ArgumentNullException>(() => new NotaFiscal(null!, destino, "1", "", "", TipoNota.NFS, 10, DateTime.Now, DateTime.Now, ""));
+        }
+
+        [Fact]
+        public void CriarNotaFiscal_ComValorTotalInvalido_DeveLancarExcecao()
+        {
+            var origem = DummyEmpresa("Origem", "12345678910111");
+            var destino = DummyEmpresa("Destino", "10987654321011");
+            Assert.Throws<ArgumentException>(() => new NotaFiscal(origem, destino, "1", "", "", TipoNota.NFS, 0, DateTime.Now, DateTime.Now, ""));
+        }
+
+        [Fact]
+        public void ToString_DeveRetornarFormatoCorreto()
+        {
+            var origem = DummyEmpresa("Origem", "12345678910111");
+            var destino = DummyEmpresa("Destino", "10987654321011");
+            var nota = new NotaFiscal(origem, destino, "1", "chave", "1", TipoNota.NFE, 50m, new DateTime(2024, 1, 2), new DateTime(2024, 1, 3), "desc");
+            var texto = nota.ToString();
+            Assert.Contains("NFE 1", texto);
+            Assert.Contains("02/01/2024", texto);
+        }
+    }
+}

--- a/notas.Tests/TestNotaFiscalService.cs
+++ b/notas.Tests/TestNotaFiscalService.cs
@@ -84,5 +84,56 @@ namespace notas.Tests
             Assert.NotNull(resultado);
             notaRepoMock.Verify(r => r.SalvarAsync(It.IsAny<NotaFiscal>()), Times.Once);
         }
+
+        [Fact]
+        public async Task CriarNotaFiscalAsync_DeveLancarExcecao_QuandoValorInvalido()
+        {
+            var notaRepoMock = new Mock<INotaFiscalRepository>();
+            var empresaRepoMock = new Mock<IEmpresaRepository>();
+
+            var endereco = new Endereco("Rua Teste", "", "123", "Centro", "Cidade", UF.MG, "30110-020");
+            var empresaOrigem = new Empresa("Origem", "Origem", "12345678910111", endereco);
+            var empresaDestino = new Empresa("Destino", "Destino", "10987654321011", endereco);
+            empresaRepoMock.Setup(r => r.BuscarPorIdAsync(1)).ReturnsAsync(empresaOrigem);
+            empresaRepoMock.Setup(r => r.BuscarPorIdAsync(2)).ReturnsAsync(empresaDestino);
+
+            var service = new NotaFiscalService(notaRepoMock.Object, empresaRepoMock.Object);
+            var dto = new CriarNotaFiscalDto
+            {
+                EmpresaOrigemIdEmpresa = 1,
+                EmpresaDestinoIdEmpresa = 2,
+                NumeroNota = "123",
+                ChaveAcesso = "abc",
+                Serie = "A1",
+                TipoNota = TipoNota.NFS,
+                ValorTotal = 0,
+                DataEmissao = DateTime.Now,
+                DataPostagem = DateTime.Now,
+                Descricao = "Teste"
+            };
+
+            await Assert.ThrowsAsync<ArgumentException>(() => service.CriarNotaFiscalAsync(dto));
+            notaRepoMock.Verify(r => r.SalvarAsync(It.IsAny<NotaFiscal>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task ListarNotasAsync_DeveRetornarTodasNotas()
+        {
+            var notas = new List<NotaFiscal>
+            {
+                new NotaFiscal(new Empresa("A", "A", "12345678910111", new Endereco("a", "", "1", "b", "c", UF.MG, "30110-020")),
+                               new Empresa("B", "B", "10987654321011", new Endereco("a", "", "1", "b", "c", UF.MG, "30110-020")),
+                               "1", "c", "s", TipoNota.NFE, 10, DateTime.Now, DateTime.Now, ""),
+                new NotaFiscal(new Empresa("A2", "A2", "12345678910112", new Endereco("a", "", "1", "b", "c", UF.MG, "30110-020")),
+                               new Empresa("B2", "B2", "10987654321012", new Endereco("a", "", "1", "b", "c", UF.MG, "30110-020")),
+                               "2", "c", "s", TipoNota.NFE, 20, DateTime.Now, DateTime.Now, "")
+            };
+            var notaRepoMock2 = new Mock<INotaFiscalRepository>();
+            notaRepoMock2.Setup(r => r.ListarAsync()).ReturnsAsync(notas);
+            var service2 = new NotaFiscalService(notaRepoMock2.Object, new Mock<IEmpresaRepository>().Object);
+            var resultado = await service2.ListarNotasAsync();
+            Assert.Equal(2, resultado.Count());
+            notaRepoMock2.Verify(r => r.ListarAsync(), Times.Once);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add new tests covering NotaFiscal domain object
- extend existing tests for Empresa, Endereco, EmpresaService and NotaFiscalService
- these tests add coverage for edge cases and formatting

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684231630a90833296ddae41d6fc60ea