### PR TITLE
Add timestamp test for Empresa creation

### DIFF
--- a/notas.Tests/TestEmpresa.cs
+++ b/notas.Tests/TestEmpresa.cs
@@ -122,5 +122,18 @@ namespace notas.Tests
             Assert.True(empresa.DataUltimaAtualizacao > antes);
         }
 
+        [Fact]
+        public void CriarEmpresa_DeveInicializarDatasCorretamente()
+        {
+            var endereco = CriarEnderecoDummy();
+            var antes = DateTime.UtcNow;
+            var empresa = new Empresa("Teste", "Teste Fantasia", "12345678910111", endereco);
+            var dataCriacao = empresa.DataCriacao;
+
+            Assert.True(dataCriacao >= antes);
+            Assert.True(dataCriacao <= DateTime.UtcNow);
+            Assert.Equal(dataCriacao, empresa.DataUltimaAtualizacao);
+        }
+
     }
 }


### PR DESCRIPTION
## Summary
- verify Empresa initializes creation and update timestamps correctly

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684234fbf33083329bbc4e38b7f83221