### PR TITLE
Add repository integration tests

### DIFF
--- a/notas.Tests/TestEmpresaRepository.cs
+++ b/notas.Tests/TestEmpresaRepository.cs
@@ -55,5 +55,43 @@ namespace notas.Tests
             var todas = await repositorio.ListarTodasAsync();
             Assert.Equal(2, System.Linq.Enumerable.Count(todas));
         }
+
+        [Fact]
+        public async Task DeveBuscarEmpresaPorId()
+        {
+            var contexto = CriarContextoEmMemoria();
+            var repositorio = new EmpresaRepository(contexto);
+            var empresa = CriarEmpresaExemplo();
+
+            await repositorio.SalvarAsync(empresa);
+            var id = empresa.IdEmpresa;
+
+            var encontrada = await repositorio.BuscarPorIdAsync(id);
+            Assert.NotNull(encontrada);
+            Assert.Equal("Empresa Teste", encontrada!.RazaoSocial);
+        }
+
+        [Fact]
+        public async Task AtualizarAsync_DevePersistirAlteracoes()
+        {
+            var contexto = CriarContextoEmMemoria();
+            var repositorio = new EmpresaRepository(contexto);
+            var empresa = CriarEmpresaExemplo();
+
+            await repositorio.SalvarAsync(empresa);
+            var id = empresa.IdEmpresa;
+
+            empresa.AtualizarDados("Empresa Atualizada", "Nova Fantasia",
+                new Endereco("Rua B", "", "321", "Centro", "Belo Horizonte", UF.MG, "30110030"));
+
+            await repositorio.AtualizarAsync(empresa);
+
+            contexto.Entry(empresa).State = EntityState.Detached;
+            var atualizada = await repositorio.BuscarPorIdAsync(id);
+
+            Assert.NotNull(atualizada);
+            Assert.Equal("Empresa Atualizada", atualizada!.RazaoSocial);
+            Assert.Equal("Nova Fantasia", atualizada.NomeFantasia);
+        }
     }
 }

--- a/notas.Tests/TestNotaFiscalRepository.cs
+++ b/notas.Tests/TestNotaFiscalRepository.cs
@@ -39,4 +39,67 @@ public class TestNotaFiscalRepository
         Assert.Single(lista);
         Assert.Equal("NF123", lista.First().NumeroNota);
     }
+
+    private NotaFiscal CriarNotaComNumero(string numero)
+    {
+        var origem = new Empresa("Origem", "Origem LTDA", "11111111111111",
+            new Endereco("Rua A", "", "1", "Centro", "BH", UF.MG, "30110000"));
+        var destino = new Empresa("Destino", "Destino LTDA", "22222222222222",
+            new Endereco("Rua B", "", "2", "Savassi", "BH", UF.MG, "30120000"));
+
+        return new NotaFiscal(origem, destino, numero, "CHV" + numero, "1", TipoNota.NFE,
+            500m, DateTime.Today, DateTime.Today, "Descrição teste");
+    }
+
+    [Fact]
+    public async Task BuscarPorNumeroAsync_DeveRetornarNotaCorreta()
+    {
+        var contexto = CriarContextoEmMemoria();
+        var repositorio = new NotaFiscalRepository(contexto);
+
+        var nota1 = CriarNotaComNumero("NF1");
+        var nota2 = CriarNotaComNumero("NF2");
+
+        await repositorio.SalvarAsync(nota1);
+        await repositorio.SalvarAsync(nota2);
+
+        var encontrada = await repositorio.BuscarPorNumeroAsync("NF2");
+
+        Assert.NotNull(encontrada);
+        Assert.Equal("NF2", encontrada!.NumeroNota);
+    }
+
+    [Fact]
+    public async Task BuscarPorIdAsync_DeveRetornarComEmpresas()
+    {
+        var contexto = CriarContextoEmMemoria();
+        var repositorio = new NotaFiscalRepository(contexto);
+        var nota = CriarNotaComNumero("NFIncl");
+
+        await repositorio.SalvarAsync(nota);
+        var id = nota.IdNota;
+
+        contexto.Entry(nota).State = EntityState.Detached;
+        var encontrada = await repositorio.BuscarPorIdAsync(id);
+
+        Assert.NotNull(encontrada);
+        Assert.NotNull(encontrada!.EmpresaOrigem);
+        Assert.NotNull(encontrada!.EmpresaDestino);
+        Assert.Equal("Origem", encontrada.EmpresaOrigem.RazaoSocial);
+        Assert.Equal("Destino", encontrada.EmpresaDestino.RazaoSocial);
+    }
+
+    [Fact]
+    public async Task ExcluirAsync_DeveRemoverNota()
+    {
+        var contexto = CriarContextoEmMemoria();
+        var repositorio = new NotaFiscalRepository(contexto);
+        var nota = CriarNotaComNumero("NFDEL");
+
+        await repositorio.SalvarAsync(nota);
+        await repositorio.ExcluirAsync(nota);
+
+        var resultado = await repositorio.BuscarPorNumeroAsync("NFDEL");
+        Assert.Null(resultado);
+    }
 }


### PR DESCRIPTION
## Summary
- extend `TestNotaFiscalRepository` with additional integration tests
- extend `TestEmpresaRepository` with new tests for finding and updating

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686476bbd0888332a22984107677d838