### PR TITLE
Add HttpRequestException test

### DIFF
--- a/notas.Tests/TestViaCepService.cs
+++ b/notas.Tests/TestViaCepService.cs
@@ -67,5 +67,22 @@ namespace notas.Tests
             var endereco = await service.ObterEnderecoPorCepAsync("30110-020");
             Assert.Null(endereco);
         }
+
+        private class ThrowingHttpMessageHandler : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                throw new HttpRequestException("Network failure");
+            }
+        }
+
+        [Fact]
+        public async Task ObterEnderecoPorCepAsync_DeveRetornarNull_QuandoHttpRequestFalhar()
+        {
+            var client = new HttpClient(new ThrowingHttpMessageHandler());
+            var service = new ViaCepService(client);
+            var endereco = await service.ObterEnderecoPorCepAsync("30110-020");
+            Assert.Null(endereco);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- expand ViaCepService tests to handle request failure with a custom message handler that throws `HttpRequestException`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686476461f888332b81f69ff6f921327